### PR TITLE
feat: support `github-actions-workflow` language

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -2,51 +2,58 @@ const { spawnSync } = require("node:child_process");
 const { dirname } = require("node:path");
 const vscode = require("vscode");
 
+const yamlformattedLanguages = [
+  "yaml",
+  "github-actions-workflow" // Provided in https://github.com/github/vscode-github-actions
+];
+const provider = {
+  provideDocumentFormattingEdits(document) {
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+    const config = vscode.workspace.getConfiguration("", document.uri);
+
+    const args = config.get("yamlfmt.args", []).filter(arg => arg !== "-in");
+    args.push("-in");
+
+    const result = spawnSync("yamlfmt", args, {
+      cwd: workspaceFolder ? workspaceFolder.uri.fsPath : dirname(document.uri.fsPath),
+      input: document.getText(),
+    });
+
+    if (result.error) {
+      console.error(result.error);
+      const prefix = "spawnSync ";
+      vscode.window.showErrorMessage(
+        result.error.message.startsWith(prefix) ?
+          result.error.message.substring(prefix.length) :
+          result.error.message
+      );
+      return [];
+    }
+
+    if (result.stderr.length > 0) {
+      console.log(result.stderr.toString());
+      vscode.window.showErrorMessage(result.stderr.toString());
+      return [];
+    }
+
+    if (result.stdout.length < 1) {
+      console.warn("yamlfmt's stdout buffer is empty");
+      return [];
+    }
+
+    const range = new vscode.Range(
+      document.lineAt(0).range.start,
+      document.lineAt(document.lineCount - 1).range.end,
+    );
+
+    return [vscode.TextEdit.replace(range, result.stdout.toString())];
+  }
+};
 
 function activate() {
-  vscode.languages.registerDocumentFormattingEditProvider("yaml", {
-    provideDocumentFormattingEdits(document) {
-      const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
-      const config = vscode.workspace.getConfiguration("", document.uri);
-
-      const args = config.get("yamlfmt.args", []).filter(arg => arg !== "-in");
-      args.push("-in");
-
-      const result = spawnSync("yamlfmt", args, {
-        cwd: workspaceFolder ? workspaceFolder.uri.fsPath : dirname(document.uri.fsPath),
-        input: document.getText(),
-      });
-
-      if (result.error) {
-        console.error(result.error);
-        const prefix = "spawnSync ";
-        vscode.window.showErrorMessage(
-          result.error.message.startsWith(prefix) ?
-            result.error.message.substring(prefix.length) :
-            result.error.message
-        );
-        return [];
-      }
-
-      if (result.stderr.length > 0) {
-        console.log(result.stderr.toString());
-        vscode.window.showErrorMessage(result.stderr.toString());
-        return [];
-      }
-
-      if (result.stdout.length < 1) {
-        console.warn("yamlfmt's stdout buffer is empty");
-        return [];
-      }
-
-      const range = new vscode.Range(
-        document.lineAt(0).range.start,
-        document.lineAt(document.lineCount - 1).range.end,
-      );
-
-      return [vscode.TextEdit.replace(range, result.stdout.toString())];
-    }
-  });
+  for (const lang of yamlformattedLanguages) {
+    vscode.languages.registerDocumentFormattingEditProvider(lang, provider);
+  }
 }
 
 function deactivate() { }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "multi-root ready"
   ],
   "activationEvents": [
-    "onLanguage:yaml"
+    "onLanguage:yaml",
+    "onLanguage:github-actions-workflow"
   ],
   "main": "./extension.js",
   "contributes": {


### PR DESCRIPTION
This is a restriction from another extension, please see https://github.com/github/vscode-github-actions/issues/195 for further detail.

---

GitHub provides useful extension for GitHub Actions workflow, but [it marks the YAML files as another language](https://github.com/github/vscode-github-actions/blob/02a4f12047a38409abce525e45650235499db371/package.json#L33-L41).

If enabling both their extension and this formatter requires switching the language mode from the VScode UI and switching again to use their extension.
 
After this pull request, the following config enables this formatter while keeping the language ID for GitHub Actions workflows.

```json
{
  "[yaml]": {
    "editor.defaultFormatter": "bluebrown.yamlfmt"
  },
  "[github-actions-workflow]": {
    "editor.defaultFormatter": "bluebrown.yamlfmt"
  }
}
```

I don't think this is a beautiful solution, this means one extension depends on another extension. 
If you know a better way, please close this PR 🙏