### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+- package-ecosystem: 'github-actions'
+  directory: '/'
+  schedule:
+    interval: 'weekly'
+- package-ecosystem: 'npm'
+  directory: '/'
+  schedule:
+    interval: 'weekly'
+  ignore:
+  - dependency-name: '@types/*'
+    update-types: ['version-update:semver-major']


### PR DESCRIPTION
How about enabling dependabot to prevent dependency problems as they appeared in #8?

* yaml has been formatted with current .yamlfmt
* ignored types dependency to avoid unexpected difference with types and logics. (Now engine is specified nodejs 16, but the types are nodejs 20)
  * https://github.com/bluebrown/vscode-extension-yamlfmt/blob/1c97b2d383f29defc2cc05e8e56c590dbb7ba7ec/package.json#L57
  * https://github.com/bluebrown/vscode-extension-yamlfmt/blob/1c97b2d383f29defc2cc05e8e56c590dbb7ba7ec/.github/workflows/check.yaml#L26