### PR TITLE
chore(ci): bump nodejs to 20.x

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: Set up Go
       uses: actions/setup-go@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: Install dependencies
       run: npm install


### PR DESCRIPTION
Node.js 16 End-of-Life is 2023-09-11

https://nodejs.org/en/blog/announcements/nodejs16-eol/