### PR TITLE
feat: support `dockercompose` language

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -4,7 +4,8 @@ const vscode = require("vscode");
 
 const yamlformattedLanguages = [
   "yaml",
-  "github-actions-workflow" // Provided in https://github.com/github/vscode-github-actions
+  "github-actions-workflow", // Provided in https://github.com/github/vscode-github-actions
+  "dockercompose", // Provided in https://github.com/Microsoft/vscode-docker
 ];
 const provider = {
   provideDocumentFormattingEdits(document) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   ],
   "activationEvents": [
     "onLanguage:yaml",
-    "onLanguage:github-actions-workflow"
+    "onLanguage:github-actions-workflow",
+    "onLanguage:dockercompose"
   ],
   "main": "./extension.js",
   "contributes": {


### PR DESCRIPTION
This is the same as #9 but for Docker Compose files.

There's issues (see microsoft/vscode-docker#4196, microsoft/vscode-docker#4220) in the Docker extension repository which reference redhat-developer/vscode-yaml#1000, but none of them noticed that the developers of RedHat's YAML extension [already closed a similar issue as won't fix](https://github.com/redhat-developer/vscode-yaml/issues/484#issuecomment-1059885640).

With this PR, this extension would at least fill the gap that RedHat's extension doesn't (seem to) want to support.

The following lines should be added to the `settings.json` file, as well as installing the [Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker):

```json
{
  "[dockercompose]": {
    "editor.defaultFormatter": "bluebrown.yamlfmt"
  }
}
```

PS.: I had to change the `engines.vscode` property in `package.json` for the extension to be packaged. I don't know if you want me to change that for you in this PR or want to do it yourself. Tests might fail due to this.