### PR TITLE
Add "ansible" to formattedLanguages

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -6,6 +6,7 @@ const yamlformattedLanguages = [
   "yaml",
   "github-actions-workflow", // Provided in https://github.com/github/vscode-github-actions
   "dockercompose", // Provided in https://github.com/Microsoft/vscode-docker
+  "ansible", // Provided in https://github.com/ansible/vscode-ansible
 ];
 const provider = {
   provideDocumentFormattingEdits(document) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "activationEvents": [
     "onLanguage:yaml",
     "onLanguage:github-actions-workflow",
-    "onLanguage:dockercompose"
+    "onLanguage:dockercompose",
+    "onLanguage:ansible"
   ],
   "main": "./extension.js",
   "contributes": {


### PR DESCRIPTION
Hopefully I did this right - this should add support for Ansible's `.yaml` files.